### PR TITLE
增加 保留文件的功能，增加webDir支持数组类型

### DIFF
--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -137,8 +137,8 @@ const disconnectSSH = () => {
 
 // 删除本地打包文件
 const removeLocalFile = (config) => {
-  const localPath = `${process.cwd()}/${distPath}`
   const {distPath,preserveLocal}=config
+  const localPath = `${process.cwd()}/${distPath}`
   if (preserveLocal) {
     return log(`(5) 保留本地打包目录 ${underline(localPath)}`)
   }

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -190,7 +190,7 @@ module.exports = {
         }
 
         disconnectSSH()
-        removeLocalFile(envConfig.distPath)
+        removeLocalFile(envConfig)
         succeed(
           `恭喜您，${underline(projectName)}项目已在${underline(
             envConfig.name

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -92,8 +92,12 @@ const connectSSH = async (config) => {
 }
 
 // 删除远程文件
-const removeRemoteFile = async (webDir) => {
+const removeRemoteFile = async (config) => {
   try {
+    const {webDir,preserve}=config
+    if (preserve) {
+      return  log(`(3) 保留远程文件 ${underline(webDir)}`)
+    }
     log(`(3) 删除远程文件 ${underline(webDir)}`)
     await ssh.execCommand(`rm -rf ${webDir}`)
     succeed('删除成功')
@@ -132,9 +136,12 @@ const disconnectSSH = () => {
 }
 
 // 删除本地打包文件
-const removeLocalFile = (distPath) => {
+const removeLocalFile = (config) => {
   const localPath = `${process.cwd()}/${distPath}`
-
+  const {distPath,preserveLocal}=config
+  if (preserveLocal) {
+    return log(`(5) 保留本地打包目录 ${underline(localPath)}`)
+  }
   log(`(5) 删除本地打包目录 ${underline(localPath)}`)
 
   const remove = (path) => {
@@ -171,8 +178,17 @@ module.exports = {
       if (answers.confirm) {
         await execBuild(envConfig.script)
         await connectSSH(envConfig)
-        await removeRemoteFile(envConfig.webDir)
-        await uploadLocalFile(envConfig)
+
+        const webDir =
+          Object.prototype.toString.call(envConfig.webDir) === '[object Array]'
+            ? envConfig.webDir
+            : [envConfig.webDir]
+        for (let dir of webDir) {
+          envConfig.webDir = dir
+          await removeRemoteFile(envConfig)
+          await uploadLocalFile(envConfig)
+        }
+
         disconnectSSH()
         removeLocalFile(envConfig.distPath)
         succeed(


### PR DESCRIPTION
解决 [issue#1](https://github.com/fuchengwei/deploy-cli-service/issues/1)
增加两个配置，preserve,preserveLocal;保留远端文件和本地文件。
增加webDir可选为数组类型，数组类型会覆盖到多个文件夹下，同时仍支持字符串类型。

---

由于我公司的线上环境为一台主机配置多个节点的分布式系统，所以需要放在多个文件夹下。如果是多台主机下，是否需要支持多个host，由于我没有多主机的测试环境，我没有深入